### PR TITLE
test of PloverDB ITRB deployment system

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ _Hardware requirements_: A host machine with 128 GiB of memory is recommended fo
     * `docker build -t yourimage .`
     * `docker run -d --name yourcontainer -p 9990:80 yourimage`
 
-Building the image should take 20-30 minutes for KG2c. Upon starting the container, it will be a few minutes (appx. 5 minutes) until the app is fully loaded and ready for use; you can do `docker logs yourcontainer` to check on its progress. After running `docker run`, wait five minutes and then run `docker logs yourcontainer`, and if you see output like this:
+Building the image should take 20-30 minutes for KG2c. Upon starting the container, it will be approximately 15 minutes until the app is fully loaded and ready for use; you can do `docker logs yourcontainer` to check on its progress. After running `docker run`, wait five minutes and then run `docker logs yourcontainer`, and if you see output like this:
 ```
 2023-06-29 21:13:56,028 INFO: Indexes are fully loaded! Took 5.52 minutes.
 WSGI app 0 (mountpoint='') ready in 332 seconds on interpreter 0x5629c42d36f0 pid: 10 (default app)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-g# PloverDB
+# PloverDB
 
 Plover is a prototype **read-only in-memory database service** that can answer **one-hop queries** on a given biomedical knowledge graph (supplied in JSON [Biolink](https://biolink.github.io/biolink-model/) format).
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,11 @@ running "unix_signal:15 gracefully_kill_them_all" (master-start)...
 ```
 And if you can connect locally (on the PloverDB server, if you have shell access) to port 9990 like this:
 ```
-telnet 0 9990
+nc -v 0 9990
 ```
 if you see
 ```
-Trying 0.0.0.0...
-Connected to 0.
-Escape character is '^]'.
+Connection to 0 9990 port [tcp/*] succeeded!
 ```
 then PloverDB is running and ready. Send a `Ctrl-C` to disconnect and you are ready to use or test PloverDB.
 You should now be able to send it POST requests at the port you opened; the URL for this would look something like: `http://yourinstance.rtx.ai:9990/query/`. Or, if you just want to use it locally: `http://localhost:9990/query/`.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ If you want to save the contents of the log to a file locally, run:
 docker logs mycontainer >& logs/mylog.log
 ```
 
+If you want to use cURL to debug PloverDB, make sure to specify the `-L` (i.e., `--location`) option for the `curl` command, since PloverDB seems to use redirection. Like this:
+```
+curl -L -X POST -d @test20.json -H 'Content-Type: application/json' -H 'accept: application/json' http://kg2cplover2.rtx.ai:9990/query
+```
+
 ### Credits
 
 * Author: Amy Glen

--- a/app/app/plover.py
+++ b/app/app/plover.py
@@ -14,7 +14,7 @@ from typing import List, Dict, Union, Set, Optional, Tuple
 import psutil
 
 SCRIPT_DIR = f"{os.path.dirname(os.path.abspath(__file__))}"
-
+KG2C_DUMP_URL_BASE = "https://kg2webhost.rtx.ai"
 
 class PloverDB:
 
@@ -436,9 +436,10 @@ class PloverDB:
 
     @staticmethod
     def _download_and_unzip_remote_file(remote_file_name: str, local_destination_path: str):
-        logging.info(f"Downloading remote file {remote_file_name} from translator-lfs-artifacts repo")
         temp_location = f"{SCRIPT_DIR}/{remote_file_name}"
-        remote_path = f"https://github.com/ncats/translator-lfs-artifacts/blob/main/files/{remote_file_name}?raw=true"
+#        remote_path = f"https://github.com/ncats/translator-lfs-artifacts/blob/main/files/{remote_file_name}?raw=true"
+        remote_path = f"{KG2C_DUMP_URL_BASE}/{remote_file_name}"
+        logging.info(f"Downloading remote file from URL: {remote_path}")
         subprocess.check_call(["curl", "-L", remote_path, "-o", temp_location])
         if remote_file_name.endswith(".gz"):
             logging.info(f"Unzipping downloaded file")

--- a/app/kg_config.json
+++ b/app/kg_config.json
@@ -1,6 +1,6 @@
 {
   "local_kg_file_name": null,
-  "remote_kg_file_name": "kg2c_lite_2.8.0.1.json.gz",
+  "remote_kg_file_name": "kg2c_lite_2.8.3.json.gz",
   "remote_index_file_name": null,
   "is_test": false,
   "biolink_helper_branch": "master",

--- a/test/test.py
+++ b/test/test.py
@@ -641,7 +641,7 @@ def test_21():
                         {"qualifier_type_id": "biolink:qualified_predicate",
                          "qualifier_value": "biolink:causes"},
                         {"qualifier_type_id": "biolink:object_direction_qualifier",
-                         "qualifier_value": "increased"},
+                         "qualifier_value": "decreased"},
                         {"qualifier_type_id": "biolink:object_aspect_qualifier",
                          "qualifier_value": "activity_or_abundance"}
                     ]}
@@ -650,7 +650,7 @@ def test_21():
         },
         "nodes": {
             "n00": {
-                "ids": [CAUSES_INCREASE_CURIE]
+                "ids": ["PUBCHEM.COMPOUND:6323266"]
             },
             "n01": {
                 "categories": ["biolink:NamedThing"]
@@ -659,7 +659,7 @@ def test_21():
         "include_metadata": True
     }
     kg = _run_query(query)
-    assert INCREASED_CURIE in kg["nodes"]["n01"]
+    assert "NCBIGene:1890" in kg["nodes"]["n01"]
 
 
 def test_22():
@@ -674,8 +674,6 @@ def test_22():
                     {"qualifier_set": [
                         {"qualifier_type_id": "biolink:qualified_predicate",
                          "qualifier_value": "biolink:causes"},
-                        # {"qualifier_type_id": "biolink:object_direction_qualifier",
-                        #  "qualifier_value": "increased"},
                         {"qualifier_type_id": "biolink:object_aspect_qualifier",
                          "qualifier_value": "activity_or_abundance"}
                     ]}
@@ -684,7 +682,7 @@ def test_22():
         },
         "nodes": {
             "n00": {
-                "ids": [CAUSES_INCREASE_CURIE]
+                "ids": ["PUBCHEM.COMPOUND:6323266"]
             },
             "n01": {
                 "categories": ["biolink:NamedThing"]
@@ -693,7 +691,7 @@ def test_22():
         "include_metadata": True
     }
     kg = _run_query(query)
-    assert INCREASED_CURIE in kg["nodes"]["n01"]
+    assert "NCBIGene:1890" in kg["nodes"]["n01"]
 
 
 def test_23():
@@ -859,7 +857,7 @@ def test_28():
                         {"qualifier_type_id": "biolink:qualified_predicate",
                          "qualifier_value": "biolink:causes"},
                         {"qualifier_type_id": "biolink:object_direction_qualifier",
-                         "qualifier_value": "increased"},
+                         "qualifier_value": "decreased"},
                         {"qualifier_type_id": "biolink:object_aspect_qualifier",
                          "qualifier_value": "activity_or_abundance"}
                     ]}
@@ -868,7 +866,7 @@ def test_28():
         },
         "nodes": {
             "n00": {
-                "ids": [CAUSES_INCREASE_CURIE]
+                "ids": ["PUBCHEM.COMPOUND:6323266"]
             },
             "n01": {
                 "categories": ["biolink:NamedThing"]
@@ -877,7 +875,7 @@ def test_28():
         "include_metadata": True
     }
     kg = _run_query(query)
-    assert INCREASED_CURIE in kg["nodes"]["n01"]
+    assert "NCBIGene:1890" in kg["nodes"]["n01"]
 
 
 def test_29():
@@ -892,7 +890,7 @@ def test_29():
                         {"qualifier_type_id": "biolink:qualified_predicate",
                          "qualifier_value": "biolink:causes"},
                         {"qualifier_type_id": "biolink:object_direction_qualifier",
-                         "qualifier_value": "increased"},
+                         "qualifier_value": "decreased"},
                         {"qualifier_type_id": "biolink:object_aspect_qualifier",
                          "qualifier_value": "activity_or_abundance"}
                     ]}
@@ -901,7 +899,7 @@ def test_29():
         },
         "nodes": {
             "n00": {
-                "ids": [CAUSES_INCREASE_CURIE]
+                "ids": ["PUBCHEM.COMPOUND:6323266"]
             },
             "n01": {
                 "categories": ["biolink:NamedThing"]
@@ -910,7 +908,7 @@ def test_29():
         "include_metadata": True
     }
     kg = _run_query(query)
-    assert INCREASED_CURIE in kg["nodes"]["n01"]
+    assert "NCBIGene:1890" in kg["nodes"]["n01"]
 
 
 def test_30():
@@ -922,10 +920,6 @@ def test_30():
                 "object": "n01",
                 "qualifier_constraints": [
                     {"qualifier_set": [
-                        # {"qualifier_type_id": "biolink:qualified_predicate",
-                        #  "qualifier_value": "biolink:causes"},
-                        # {"qualifier_type_id": "biolink:object_direction_qualifier",
-                        #  "qualifier_value": "increased"},
                         {"qualifier_type_id": "biolink:object_aspect_qualifier",
                          "qualifier_value": "activity_or_abundance"}
                     ]}
@@ -934,7 +928,7 @@ def test_30():
         },
         "nodes": {
             "n00": {
-                "ids": [CAUSES_INCREASE_CURIE]
+                "ids": ["PUBCHEM.COMPOUND:6323266"]
             },
             "n01": {
                 "categories": ["biolink:NamedThing"]
@@ -943,7 +937,7 @@ def test_30():
         "include_metadata": True
     }
     kg = _run_query(query)
-    assert INCREASED_CURIE in kg["nodes"]["n01"]
+    assert "NCBIGene:1890" in kg["nodes"]["n01"]
 
 
 def test_31():


### PR DESCRIPTION
OK, I am going to do a simple two-step test. I am going to
1. merge the `RTXteam/PloverDB` project's `main` branch into `itrb-test` and
2. commit a trivial (non-functional) change to `main` (just to trigger a ITRB CI build)

If [kg2cploverdb.ci.transltr.io](http://kg2cploverdb.ci.transltr.io/) is truly being built from main, this should have no effect on the running service on [kg2cploverdb.ci.transltr.io](http://kg2cploverdb.ci.transltr.io/) once it comes back up; it should act exactly like it does now.