### PR TITLE
Migrate to python:3.12 + gunicorn, fix pygit2 uid/gid ownership #70

### DIFF
--- a/app/nginx_host_proxy_template.conf
+++ b/app/nginx_host_proxy_template.conf
@@ -1,0 +1,32 @@
+# Nginx reverse proxy config for host (SSL termination)
+# Install: sudo cp nginx_host_proxy.conf /etc/nginx/sites-available/kg2cplover
+#          sudo ln -s /etc/nginx/sites-available/kg2cplover /etc/nginx/sites-enabled/
+#          sudo nginx -t && sudo systemctl reload nginx
+
+server {
+    listen 9990 ssl;
+    server_name kg2cplover.rtx.ai;
+
+    ssl_certificate /etc/letsencrypt/live/kg2cplover.rtx.ai/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/kg2cplover.rtx.ai/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    # Proxy to container (HTTP on internal port)
+    location / {
+        proxy_pass http://127.0.0.1:9991;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Timeout settings for long-running queries
+        proxy_connect_timeout 600;
+        proxy_send_timeout 600;
+        proxy_read_timeout 600;
+    }
+
+    access_log /var/log/nginx/kg2cplover_access.log;
+    error_log /var/log/nginx/kg2cplover_error.log;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ fastapi
 fastapi[standard]
 flask
 flask-cors
+gunicorn
 opentelemetry-exporter-jaeger==1.17.0
 opentelemetry-instrumentation-flask==0.38b0
 biolink-helper-pkg==1.0.0

--- a/run.sh
+++ b/run.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 # Usage: bash -x run.sh [-b branch name to build from] [-i image name] [-c container name]
 #                       [-d docker command i.e., "docker" or "sudo docker"] [-p host port to run on]
-#                       [-s true, if want to skip ssl cert configuration, otherwise omit this parameter]
 # Example1: bash -x run.sh -b ctkp
-# Example2: bash -x run.sh -i myimage -c mycontainer -d docker -s true -p 9990
+# Example2: bash -x run.sh -i myimage -c mycontainer -d docker -p 9990
+#
+# NOTE: SSL/HTTPS is now handled outside the container (e.g., by a reverse proxy on the host
+#       or by a Kubernetes ingress controller). The container only serves HTTP on port 80.
 
 set -e  # Stop on error
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Specify default values for optional parameters
-skip_ssl="false"
 branch=""
-host_port="9990"
+host_port="9991"  # Internal port; nginx handles external 9990 with SSL
 image_name=ploverimage
 container_name=plovercontainer
 # Auto-detect if "docker" can run without sudo
@@ -23,13 +24,12 @@ else
 fi
 
 # Override defaults with values from any optional parameters provided
-while getopts "i:c:d:b:s:p:" flag; do
+while getopts "i:c:d:b:p:" flag; do
 case "$flag" in
     i) image_name=$OPTARG;;
     c) container_name=$OPTARG;;
     d) docker_command=$OPTARG;;
     b) branch=$OPTARG;;
-    s) skip_ssl=$OPTARG;;
     p) host_port=$OPTARG;;
 esac
 done
@@ -40,28 +40,6 @@ if [ ${branch} ]; then
   git fetch
   git checkout ${branch}
   git pull origin ${branch}
-fi
-
-# Determine whether we have a local domain name file
-if [[ -f "${SCRIPT_DIR}/app/domain_name.txt" ]]; then
-    domain_name_file_exists=1
-    domain_name=$(head -n 1 "${SCRIPT_DIR}/app/domain_name.txt")
-else
-    domain_name_file_exists=0
-    if [ "$skip_ssl" != "true" ]; then
-      echo "Will not configure SSL certs because local domain_name.txt file does not exist."
-    fi
-fi
-
-# Set up nginx config as appropriate, if want to use ssl/HTTPS
-if [[ ${domain_name_file_exists} -eq 1 && ${skip_ssl} != "true" ]]; then
-  cp ${SCRIPT_DIR}/app/nginx_ssl_template.conf ${SCRIPT_DIR}/app/nginx.conf
-  # Plug the proper domain name into the nginx config file
-  sed -i -e "s/{{domain_name}}/${domain_name}/g" ${SCRIPT_DIR}/app/nginx.conf
-else
-  set +e
-  rm ${SCRIPT_DIR}/app/nginx.conf
-  set -e
 fi
 
 # Build the docker image
@@ -80,17 +58,8 @@ for container_id in $(${docker_command} ps -q); do
 done
 set -e  # Stop on error
 
-# Run the docker container
-if [[ ${skip_ssl} == "true" || ${domain_name_file_exists} -eq 0 ]]; then
-  # Skip configuring SSL certs
-  ${docker_command} run -d --name ${container_name} -p ${host_port}:80 ${image_name}
-else
-  # Ensure our SSL cert is current and load it into the container (on run)
-  sudo certbot renew
-  cert_file_path=/etc/letsencrypt/live/${domain_name}/fullchain.pem
-  key_file_path=/etc/letsencrypt/live/${domain_name}/privkey.pem
-  ${docker_command} run -v ${cert_file_path}:${cert_file_path} -v ${key_file_path}:${key_file_path} -d --name ${container_name} -p ${host_port}:443 ${image_name}
-fi
+# Run the docker container (HTTP only - SSL handled externally if needed)
+${docker_command} run -d --name ${container_name} -p ${host_port}:80 ${image_name}
 
 # Clean up unused/stopped docker items
 ${docker_command} container prune --force


### PR DESCRIPTION
This code was tested on self hosted AWS r5a.8xlarge instance `kg2cplover.rtx.ai`
The new DockerFile was used to rebuild image from scratch using `FROM python:3.12` instead of `FROM tiangolo/uwsgi-nginx-flask:python3.11` as per @edeutsch suggestion

EXPERIMENTAL: This change may be reverted if it fails on ITRB Kubernetes.

Changes:
- Replace tiangolo/uwsgi-nginx-flask with python:3.12 + gunicorn
- Create plover user (uid 1000) for proper .git ownership
- Add --preload for memory-efficient worker spawning
- Add configurable PORT env var for ITRB flexibility
- Add /debug and improved /healthcheck endpoints
- Add nginx_host_proxy.conf for SSL termination on host
- Update README for gunicorn references