### PR TITLE
Fix for  nginx watchdog, log rotation, uwsgi/nginx hardening #73

### DIFF
--- a/app/logrotate.conf
+++ b/app/logrotate.conf
@@ -1,0 +1,24 @@
+# rotate uwsgi and nginx logs daily, keep 3 days.
+# maxsize triggers rotation mid-day if a log grows too fast under heavy traffic.
+# copytruncate avoids reopening file descriptors in uwsgi/nginx.
+# the watchdog in start.sh calls logrotate every 30s, so checks are frequent.
+
+/var/log/uwsgi.log {
+    daily
+    rotate 3
+    missingok
+    notifempty
+    compress
+    copytruncate
+    maxsize 50M
+}
+
+/var/log/nginx/*.log {
+    daily
+    rotate 3
+    missingok
+    notifempty
+    compress
+    copytruncate
+    maxsize 25M
+}

--- a/app/nginx.conf
+++ b/app/nginx.conf
@@ -21,12 +21,30 @@ http {
     sendfile    on;
     keepalive_timeout  65;
 
+    client_max_body_size 16m;
+
+    # buffer upstream responses so slow clients don't hold uwsgi workers
+    uwsgi_buffering on;
+    uwsgi_buffers 16 64k;
+    uwsgi_buffer_size 64k;
+    uwsgi_busy_buffers_size 128k;
+
     server {
         listen 80;
         location / {
             include uwsgi_params;
             uwsgi_pass unix:///tmp/uwsgi.sock;
-            uwsgi_read_timeout 75;
+            uwsgi_read_timeout 120;
+            uwsgi_send_timeout 30;
+            uwsgi_connect_timeout 10;
+        }
+
+        # short timeout for healthchecks so ALB probes succeed
+        # even when workers are busy with slow queries
+        location = /healthcheck {
+            include uwsgi_params;
+            uwsgi_pass unix:///tmp/uwsgi.sock;
+            uwsgi_read_timeout 10;
         }
     }
 }

--- a/app/uwsgi.ini
+++ b/app/uwsgi.ini
@@ -2,8 +2,6 @@
 
 module = app.main
 callable = app
-uid = plover
-gid = plover
 buffer-size = 65535
 post-buffering = 32768
 logto = /var/log/uwsgi.log
@@ -15,6 +13,11 @@ max-worker-lifetime-delta = 60
 skip-atexit-teardown = true
 skip-atexit = true
 
+# NOTE: reload-on-rss is NOT used here. gc.freeze() + fork() creates CoW shared
+# pages, so each worker starts at ~88 GB RSS (almost all shared). Setting
+# reload-on-rss to any value below ~90000 would cause an infinite recycling
+# storm. max-worker-lifetime (14400s = 4h) handles long-term worker recycling.
+
 # =============================================================================
 # REQUIRED ADDITIONS FOR PYTHON 3.12 (migrating from tiangolo python:3.11)
 # The tiangolo/uwsgi-nginx-flask image provided these settings automatically.
@@ -25,6 +28,9 @@ skip-atexit = true
 # we restored nginx inside the container (#73) so we use the same unix socket.
 # without nginx (http-socket mode), there's no connection buffering and the
 # kernel listen backlog fills up under sustained load, causing 504s.
+# nginx absorbs connection bursts, so uwsgi only needs a modest backlog
+listen = 512
+
 socket = /tmp/uwsgi.sock
 chmod-socket = 666
 


### PR DESCRIPTION
- add nginx_is_alive() watchdog in start.sh (zombie-aware, 30s cycle)
- add logrotate.conf for uwsgi/nginx logs (prevents disk fill)
- add uwsgi_buffering + dedicated /healthcheck in nginx.conf
- increase listen backlog to 512, remove duplicate uid/gid in uwsgi.ini